### PR TITLE
Fix deadlock in semaphore::Acquire::poll

### DIFF
--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -105,7 +105,7 @@ impl Future for Acquire<'_> {
             if let Err(e) = node.take_removed(&lock.waiters) {
                 // Someone has polled us again, but we haven't been woken yet.
                 // We update the waker, then go back to sleep.
-                *e.protected_mut(&mut projected.semaphore.inner.lock().waiters)
+                *e.protected_mut(&mut lock.waiters)
                     .unwrap() = cx.waker().clone();
                 return Poll::Pending;
             }


### PR DESCRIPTION
Hello again! I hit this deadlock while using the semaphore in one of my load tests.

I started adding loom integration so that I could demonstrate the deadlock, but it started getting pretty involved (e.g. to work around the fact that loom::Mutex::new is not `const fn`). I'm happy to complete this work though - would you be interested in [loom](https://docs.rs/loom/latest/loom/) tests?

P.S. sorry for the delay on local variant of semaphore, still planning to do that.